### PR TITLE
Chore/allow semver

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,23 @@
+name: CI
+
+on:
+  pull_request:
+    branches:
+      - develop
+
+jobs:
+  ci:
+    name: Run CI
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [ 12.x ]
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup and test.
+        uses: actions/setup-node@v2
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: 'yarn'
+      - run: yarn install
+      - run: yarn test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,5 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node-version }}
-          cache: 'yarn'
       - run: yarn install
       - run: yarn test

--- a/action.yml
+++ b/action.yml
@@ -21,6 +21,10 @@ inputs:
     description: Run code before uploading the tag, e.g. re-build packages with updated version.
     required: false
     default: ""
+  use_semver:
+    description: Use conventional MAJOR.MINOR.PATCH; hotfix branches will incremember PATCH version. Defaults to false.
+    required: true
+    default: "false"
 runs:
   using: node12
   main: dist/bundle.js

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,7 @@ new Promise(async () => {
     const tmp_version_file = core.getInput("version_file")
     const skip_ci_commit_string = core.getInput("skip_ci_commit_string")
     const before_upload_tag = core.getInput("before_upload_tag")
+    const use_semver = Boolean(core.getInput("use_semver"))
 
     const owner = github.context.repo.owner
     const repo = github.context.repo.repo
@@ -35,7 +36,8 @@ new Promise(async () => {
             version_files: version_files,
             skip_ci_commit_string: skip_ci_commit_string,
             head_ref: head_ref,
-            before_upload_tag: before_upload_tag
+            before_upload_tag: before_upload_tag,
+            use_semver: use_semver
         }
 
         const manager = new ActionManager(input)

--- a/src/types.ts
+++ b/src/types.ts
@@ -14,5 +14,5 @@ export type VersionType = {
     major: number
     minor: number
     patch: number
-    hotfix: number
+    hotfix: number | null
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -69,9 +69,15 @@ class Utils {
             return 1
         }
 
-        if (first.hotfix > second.hotfix) {
+        if (first.hotfix != null && second.hotfix != null) {
+            if (first.hotfix > second.hotfix) {
+                return -1
+            } else if (first.hotfix < second.hotfix) {
+                return 1
+            }
+        } else if (first.hotfix != null) {
             return -1
-        } else if (first.hotfix < second.hotfix) {
+        } else if (second.hotfix != null) {
             return 1
         }
 
@@ -98,7 +104,7 @@ class Utils {
                     major: major,
                     minor: minor,
                     patch: patch,
-                    hotfix: 0
+                    hotfix: null
                 }
             } else if (l == 4) {
                 const str_hotfix = split[3]
@@ -116,24 +122,35 @@ class Utils {
         return null
     }
 
-    static getNewVersion = (current_version: VersionType, branch_type: BranchType): VersionType | null => {
+    static getNewVersion = (current_version: VersionType, branch_type: BranchType, use_semver: boolean): VersionType | null => {
         if (Utils.isMinorType(branch_type)) {
             return {
                 ...current_version,
                 minor: current_version.minor + 1,
                 patch: 0,
-                hotfix: 0
+                hotfix: use_semver ? null : 0
             }
         } else if (Utils.isPatchType(branch_type)) {
             return {
                 ...current_version,
                 patch: current_version.patch + 1,
-                hotfix: 0
+                hotfix: use_semver ? null : 0
             }
         } else if (Utils.isHotfixType(branch_type)) {
-            return {
-                ...current_version,
-                hotfix: current_version.hotfix + 1
+            if (use_semver) {
+                return {
+                    ...current_version,
+                    patch: current_version.patch + 1,
+                    hotfix: null
+                }
+            } else {
+                let new_hotfix: number
+                if (current_version.hotfix == null) new_hotfix = 1
+                else new_hotfix = current_version.hotfix + 1
+                return {
+                    ...current_version,
+                    hotfix: new_hotfix
+                }
             }
         } else {
             return null
@@ -142,7 +159,7 @@ class Utils {
 
     static versionTypeToString = (type: VersionType): string => {
         let suffix: string = ""
-        if (type.hotfix != 0) suffix = `.${type.hotfix}`
+        if (type.hotfix != null && type.hotfix != 0) suffix = `.${type.hotfix}`
         return `${type.major}.${type.minor}.${type.patch}${suffix}`
     }
 

--- a/tests/utils.test.ts
+++ b/tests/utils.test.ts
@@ -1,6 +1,7 @@
 import {expect} from "chai"
 
 import Utils from "../src/utils"
+import {describe} from "mocha";
 
 describe("utils", () => {
     describe("isMergeCommit", () => {
@@ -116,7 +117,7 @@ describe("utils", () => {
                 major: 0,
                 minor: 0,
                 patch: 0,
-                hotfix: 0
+                hotfix: null
             })
         })
 
@@ -126,7 +127,7 @@ describe("utils", () => {
                 major: 0,
                 minor: 0,
                 patch: 1,
-                hotfix: 0
+                hotfix: null
             })
         })
 
@@ -136,7 +137,7 @@ describe("utils", () => {
                 major: 0,
                 minor: 1,
                 patch: 0,
-                hotfix: 0
+                hotfix: null
             })
         })
 
@@ -146,7 +147,7 @@ describe("utils", () => {
                 major: 1,
                 minor: 0,
                 patch: 0,
-                hotfix: 0
+                hotfix: null
             })
         })
 
@@ -156,7 +157,7 @@ describe("utils", () => {
                 major: 0,
                 minor: 1,
                 patch: 1,
-                hotfix: 0
+                hotfix: null
             })
         })
 
@@ -166,7 +167,7 @@ describe("utils", () => {
                 major: 1,
                 minor: 1,
                 patch: 0,
-                hotfix: 0
+                hotfix: null
             })
         })
 
@@ -176,7 +177,7 @@ describe("utils", () => {
                 major: 1,
                 minor: 1,
                 patch: 1,
-                hotfix: 0
+                hotfix: null
             })
         })
 
@@ -242,44 +243,90 @@ describe("utils", () => {
     })
 
     describe("getNewVersion", () => {
-        const current_version = {
-            major: 0,
-            minor: 0,
-            patch: 0,
-            hotfix: 0
-        }
-        it("should update minor", () => {
-            const actual = Utils.getNewVersion(current_version, "feature")
-            expect(actual).to.deep.eq(
-                {
-                    major: 0,
-                    minor: 1,
-                    patch: 0,
-                    hotfix: 0
-                }
-            )
+        describe("use_semver == true", () => {
+            const use_semver = true
+            const current_version = {
+                major: 0,
+                minor: 0,
+                patch: 0,
+                hotfix: null
+            }
+            it("should update minor", () => {
+                const actual = Utils.getNewVersion(current_version, "feature", use_semver)
+                expect(actual).to.deep.eq(
+                    {
+                        major: 0,
+                        minor: 1,
+                        patch: 0,
+                        hotfix: null
+                    }
+                )
+            })
+            it("should update patch", () => {
+                const actual = Utils.getNewVersion(current_version, "chore", use_semver)
+                expect(actual).to.deep.eq(
+                    {
+                        major: 0,
+                        minor: 0,
+                        patch: 1,
+                        hotfix: null
+                    }
+                )
+            })
+            it("should update hotfix", () => {
+                const actual = Utils.getNewVersion(current_version, "hotfix", use_semver)
+                expect(actual).to.deep.eq(
+                    {
+                        major: 0,
+                        minor: 0,
+                        patch: 1,
+                        hotfix: null
+                    }
+                )
+            })
         })
-        it("should update patch", () => {
-            const actual = Utils.getNewVersion(current_version, "chore")
-            expect(actual).to.deep.eq(
-                {
-                    major: 0,
-                    minor: 0,
-                    patch: 1,
-                    hotfix: 0
-                }
-            )
-        })
-        it("should update hotfix", () => {
-            const actual = Utils.getNewVersion(current_version, "chore")
-            expect(actual).to.deep.eq(
-                {
-                    major: 0,
-                    minor: 0,
-                    patch: 1,
-                    hotfix: 0
-                }
-            )
+        describe("use_semver == false", () => {
+            const use_semver = false
+            const current_version = {
+                major: 0,
+                minor: 0,
+                patch: 0,
+                hotfix: 0
+            }
+
+            it("should update minor", () => {
+                const actual = Utils.getNewVersion(current_version, "feature", use_semver)
+                expect(actual).to.deep.eq(
+                    {
+                        major: 0,
+                        minor: 1,
+                        patch: 0,
+                        hotfix: 0
+                    }
+                )
+            })
+            it("should update patch", () => {
+                const actual = Utils.getNewVersion(current_version, "chore", use_semver)
+                expect(actual).to.deep.eq(
+                    {
+                        major: 0,
+                        minor: 0,
+                        patch: 1,
+                        hotfix: 0
+                    }
+                )
+            })
+            it("should update hotfix", () => {
+                const actual = Utils.getNewVersion(current_version, "hotfix", use_semver)
+                expect(actual).to.deep.eq(
+                    {
+                        major: 0,
+                        minor: 0,
+                        patch: 0,
+                        hotfix: 1
+                    }
+                )
+            })
         })
     })
 


### PR DESCRIPTION
## Description

- Allows for conventional semantic versioning, without hotfix as separate version (e.g. 1.0.1 vs 1.0.0.1).
- To change to semver add `use_semver: true` to your actions YML.